### PR TITLE
Ignite oven with flint and steel

### DIFF
--- a/oven.lua
+++ b/oven.lua
@@ -266,6 +266,10 @@ minetest.register_node("jelys_pizzaria:pizza_oven_fueled", {
 			start_timer(pos, 0)
 		end
 	end,
+	on_ignite = function(pos, igniter)
+		swap_node(pos, "jelys_pizzaria:pizza_oven_active")
+		start_timer(pos, 0)
+	end,
 	on_rightclick = rightclick,
 	on_timer = start_timer,
 	sounds = default.node_sound_stone_defaults(),


### PR DESCRIPTION
Currently, it's only possible to ignite logs in the oven by punching it with a torch. With this PR, you can now use flint and steel to ignite ovens, which is far more intuitive from my perspective.